### PR TITLE
Fix bug that caused DeviceInfo to always be null

### DIFF
--- a/Countly.js
+++ b/Countly.js
@@ -1,17 +1,17 @@
 import { Platform, NativeModules, AsyncStorage, Dimensions, AppState } from 'react-native';
 
+var DeviceInfo = null;
+
 try{
-  DeviceInfo = require('react-native-device-info');
-  if(!NativeModules.RNDeviceInfo){
+    DeviceInfo = require('react-native-device-info');
+    if(!NativeModules.RNDeviceInfo){
         DeviceInfo = null;
-  }
+    }
 }catch(err){
     Countly.log(err);
-  DeviceInfo = null;
 }
 
 export default Countly = {};
-var DeviceInfo = null;
 Countly.isDebug = false;
 Countly.isInit = false;
 Countly.isManualSessionHandling = false;


### PR DESCRIPTION
In the latest release, device information is not sent correctly. This is because in `Countly.js`, the line

```
var DeviceInfo = null;
```

overrides the (usually valid) earlier value. I fixed this by moving the line ahead of the code block that sets `DeviceInfo`.