### PR TITLE
 Accept callback function in Countly.init

### DIFF
--- a/Countly.js
+++ b/Countly.js
@@ -127,7 +127,7 @@ Countly.update = function(){
     Ajax.get(Countly.queue[i].url, Countly.queue[i].data, function(){});
   }
 }
-Countly.init = function(ROOT_URL, APP_KEY, DEVICE_ID) {
+Countly.init = function(ROOT_URL, APP_KEY, DEVICE_ID, callback) {
     Ajax.getItem("DEVICE_ID", function(err, S_DEVICE_ID) {
         Countly.isInit = true;
         Countly.ROOT_URL = ROOT_URL;
@@ -138,6 +138,7 @@ Countly.init = function(ROOT_URL, APP_KEY, DEVICE_ID) {
           Countly.update();
         });
 
+        callback && callback();
     });
 };
 Countly.isInitialized = function(){


### PR DESCRIPTION
This lets SDK users deal with the fact that Countly's initializer is currently _asynchronous_ (it fetches the device ID before setting `isInit = true`), which is actually rather dangerous as the user has no way of knowing about this 😬

Via the callback, users can e.g. start the session only once initialization has actually finished.

In the long run, `Countly.init` should be marked as `async` to make its asynchronous nature even more explicit to SDK users and force them to deal with it in their own code.