### PR TITLE
Use separate AsyncStorage package

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Text, Button, ScrollView, Image, AsyncStorage, Platform } from 'react-native';
+import { Text, Button, ScrollView, Image, Platform } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 // import PushNotification from 'react-native-push-notification';
 // import NotificationActions from 'react-native-ios-notification-actions';
 // import DeviceInfo from 'react-native-device-info';

--- a/Countly.js
+++ b/Countly.js
@@ -1,13 +1,13 @@
 import {
   Platform,
   NativeModules,
-  AsyncStorage,
   Alert,
   Dimensions,
   AppState,
   PushNotificationIOS,
   DeviceEventEmitter
 } from "react-native";
+import AsyncStorage from "@react-native-community/async-storage";
 
 import DeviceInfo from "react-native-device-info";
 import BackgroundTimer from "react-native-background-timer";

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "countly"
   ],
   "dependencies": {
+    "@react-native-community/async-storage": "^1.4.2",
     "crypto-js": "^3.1.9-1",
     "react-native-background-timer": "^2.0.0",
     "react-native-device-info": "^0.15.3",

--- a/util.js
+++ b/util.js
@@ -1,4 +1,4 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import SHA256 from 'crypto-js/sha256';
 import pinch from 'react-native-pinch';
 import Countly from './Countly';


### PR DESCRIPTION
Since react-native@0.59, `AsyncStorage` has been moved into a separate package, [@react-native-community/async-storage](https://github.com/react-native-community/react-native-async-storage). Importing `AsyncStorage` directly from `react-native` in 0.59 and above will print a warning. In future it will stop working.

This PR updates the imports to instead use the new separate package.